### PR TITLE
Remove debug print() in apiconnector/response.py

### DIFF
--- a/hexonet/apiconnector/response.py
+++ b/hexonet/apiconnector/response.py
@@ -36,9 +36,6 @@ class Response(RT, object):
         self.__records = []
 
         h = self.getHash()
-        print(raw)
-        print(self.getPlain())
-        print(self.__columnkeys)
         if ("PROPERTY" in h):
             colKeys = h["PROPERTY"].keys()
             count = 0


### PR DESCRIPTION
Because debug print() calls are added to response.py it show lots of noise. This output is not required and so the print should be removed.