### PR TITLE
fix(apiclient): fixed empty ConvertIDN request

### DIFF
--- a/hexonet/apiconnector/apiclient.py
+++ b/hexonet/apiconnector/apiclient.py
@@ -419,13 +419,13 @@ class APIClient(object):
         for key in cmd:
             if re.match(r'^(DOMAIN|NAMESERVER|DNSZONE)([0-9]*)$', key, re.IGNORECASE):
                 keys.append(key)
-        if not keys.count:
-            return cmd
         idxs = []
         for key in keys:
             if not re.match(r'^[a-z0-9.-]+$', cmd[key], re.IGNORECASE):
                 toconvert.append(cmd[key])
                 idxs.append(key)
+        if not toconvert:
+            return cmd
 
         r = self.request({
             "COMMAND": "ConvertIDN",


### PR DESCRIPTION
function __autoIDNConvert in class hexonet.apiconnector.apiclient.APIClient
would send an empty ConvertIDN request, if cmd contains at least one
key that matches r'^(DOMAIN|NAMESERVER|DNSZONE)([0-9]*)$', but all
values at such keys match r'^[a-z0-9.-]+$'

the result of an empty ConvertIDN request would never result in a change
of cmd and thus can be avoided.

this commit adds a check `if not toconvert` just before sending the
(empty) request in order to avoid it. for readability, the now redundant
check `if not key.count` is removed.